### PR TITLE
Code range handling using `markdownlint-rule-helpers` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,22 @@
     "": {
       "name": "markdownlint-rule-search-replace",
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "markdownlint-rule-helpers": "^0.16.0"
+      }
+    },
+    "node_modules/markdownlint-rule-helpers": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
+    }
+  },
+  "dependencies": {
+    "markdownlint-rule-helpers": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",
@@ -20,5 +20,8 @@
   "private": false,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "markdownlint-rule-helpers": "^0.16.0"
   }
 }


### PR DESCRIPTION
Used [markdownlint-rule-helpers](https://www.npmjs.com/package/markdownlint-rule-helpers) package to identify valid code ranges.

For example,
`````
These `code1` and ``code ` 2`` are valid inline code.

Line with one backtick ` is valid.

```html
This block ends with four backtics is valid :O
````
`````