### PR TITLE
Separate logic for `search` and `searchPattern`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 .markdownlint.json
 .npmrc
 .prettierignore
+.prettierrc.json
 .vscode/
 npm-debug.log
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ Here,
 
 Note, `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.
 
+In patterns, to escape characters use `\\`. For example,
+
+```json
+{
+  "default": true,
+  "search-replace": {
+    "rules": [
+      {
+        "name": "test",
+        "message": "bla bla bla",
+        "searchPattern": "^/\\.\\.\\.(.*)\\.\\.\\.$/mg",
+        "replace": "-- $1 --"
+      }
+    ]
+  }
+}
+```
+
+This will replace line `...abcd...` with `-- abcd --`.
+
 ### Disable rule options
 
 The rule can be disabled for specific section or file. For example, if you want to disable the rule for a particular section:
@@ -117,11 +137,25 @@ markdownlint test.md -r markdownlint-rule-search-replace --fix
 Add the rule object to the `customRules` array:
 
 ```js
+const markdownlint = require("markdownlint");
 const searchReplace = require("markdownlint-rule-search-replace");
 
 const options = {
-  ...
-  "customRules": [searchReplace]
+  files: ["myMarkdown.md"],
+  config: {
+    default: true,
+    "search-replace": {
+      rules: [
+        {
+          name: "m-dash",
+          message: "Don't use '--'.",
+          search: "--",
+          replace: "—",
+        },
+      ],
+    },
+  },
+  customRules: [searchReplace],
 };
 
 markdownlint(options, function callback(err, result) {

--- a/tests/applyFix-tests.js
+++ b/tests/applyFix-tests.js
@@ -56,7 +56,11 @@ test("applyFixRegex", (t) => {
     files: [inputFile],
   };
   t.is(
-    ...applyFixes(inputFile, markdownlint.sync(options), "applyFixRegex.out.md"),
+    ...applyFixes(
+      inputFile,
+      markdownlint.sync(options),
+      "applyFixRegex.out.md"
+    ),
     "Output doesn't match."
   );
 });

--- a/tests/data/replaceLine-tests.md
+++ b/tests/data/replaceLine-tests.md
@@ -1,0 +1,5 @@
+# header
+
+Some text
+...abcd...
+done

--- a/tests/data/replaceLineFix.out.md
+++ b/tests/data/replaceLineFix.out.md
@@ -1,0 +1,5 @@
+# header
+
+Some text
+-- abcd --
+done

--- a/tests/data/search_regex-tests.md
+++ b/tests/data/search_regex-tests.md
@@ -1,0 +1,3 @@
+# header
+
+Sample regex `/abc/g`.

--- a/tests/data/search_regex-tests.out.md
+++ b/tests/data/search_regex-tests.out.md
@@ -1,0 +1,3 @@
+# header
+
+Sample regex `/abc/ig`.

--- a/tests/regex-tests.js
+++ b/tests/regex-tests.js
@@ -34,3 +34,63 @@ test("htmlCommentFix", (t) => {
     "Output doesn't match."
   );
 });
+
+test("searchRegexFix", (t) => {
+  const inputFile = "./tests/data/search_regex-tests.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "use-case-insensitive",
+            message: "Use 'i' flag.",
+            search: "/abc/g",
+            replace: "/abc/ig",
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+  t.is(
+    ...applyFixes(
+      inputFile,
+      markdownlint.sync(options),
+      "search_regex-tests.out.md"
+    ),
+    "Output doesn't match."
+  );
+});
+
+test("replaceLineFix", (t) => {
+  const inputFile = "./tests/data/replaceLine-tests.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "test",
+            message: "test",
+            searchPattern: "^/\\.\\.\\.(.*)\\.\\.\\.$/mg",
+            replace: "-- $1 --",
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+  t.is(
+    ...applyFixes(
+      inputFile,
+      markdownlint.sync(options),
+      "replaceLineFix.out.md"
+    ),
+    "Output doesn't match."
+  );
+});


### PR DESCRIPTION
Avoid use of options `search` and `searchPattern` interchangeably.