### PR TITLE
Support multi-line search 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownlint-rule-search-replace",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "markdownlint-rule-helpers": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",

--- a/tests/regex-tests.js
+++ b/tests/regex-tests.js
@@ -94,3 +94,30 @@ test("replaceLineFix", (t) => {
     "Output doesn't match."
   );
 });
+
+test("multilineSearch", (t) => {
+  const inputFile = "./tests/data/options-tests.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "test",
+            message: "test",
+            searchPattern: "/some text\\nsome -- text\\nsome/mg",
+            replace: "not applicable",
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+  const result = markdownlint.sync(options);
+  const expected = `./tests/data/options-tests.md: 3: search-replace Custom rule [test: test] [Context: "column: 4 text:'some text'"]
+./tests/data/options-tests.md: 4: search-replace Custom rule [test: test] [Context: "column: 1 text:'some -- text'"]
+./tests/data/options-tests.md: 5: search-replace Custom rule [test: test] [Context: "column: 1 text:'some'"]`;
+  t.is(result.toString(), expected, "Unexpected result.");
+});


### PR DESCRIPTION
The parent project 'markdownlint' processes markdown line by line. It doesn't allow multi-line fixes. The line ending('\n') can't be removed from plugins. That is why when the 'match' is multi-line we can't suggest fix for it.

However, we can report error for each line.