### PR TITLE
Make 'replace' optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Here,
   - `message`: corresponding message
   - `search`: text to search
   - `searchPattern`: regex pattern to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
-  - `replace`: The replacement string, e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
+  - `replace`: Optional. The replacement string, e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
   - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped.
 
 Note, `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownlint-rule-search-replace",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "markdownlint-rule-helpers": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",

--- a/rule.js
+++ b/rule.js
@@ -124,7 +124,7 @@ module.exports = {
         range: [columnNo + 1, match.length],
       };
 
-      if (typeof replacement !== "undefined") {
+      if (typeof replacement !== "undefined" && replacement !== null) {
         options.fixInfo = {
           lineNumber: lineNo + 1,
           editColumn: columnNo + 1,
@@ -175,9 +175,12 @@ module.exports = {
             }
           }
         } else {
-          const replacement = rule.search
-            ? rule.replace
-            : match.replace(new RegExp(regex), rule.replace);
+          let replacement = null;
+          if (typeof rule.replace !== "undefined") {
+            replacement = rule.search
+              ? rule.replace
+              : match.replace(new RegExp(regex), rule.replace);
+          }
           report(rule, match, lineNo, columnNo, replacement);
         }
       }

--- a/tests/applyFix-tests.js
+++ b/tests/applyFix-tests.js
@@ -94,3 +94,84 @@ test("applyFixSkipCode", (t) => {
     "Output doesn't match."
   );
 });
+
+test("applyFixReplaceBackticks", (t) => {
+  const inputFile2 = "./tests/data/applyFixReplaceBackticks.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "m-dash",
+            message: "Don't use '--'.",
+            search: "````",
+            replace: "```",
+            skipCode: true,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile2],
+  };
+  t.is(
+    ...applyFixes(
+      inputFile2,
+      markdownlint.sync(options),
+      "applyFixReplaceBackticks.out.md"
+    ),
+    "Output doesn't match."
+  );
+});
+
+test("applyFixWithoutReplace", (t) => {
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "m-dash",
+            message: "Don't use '--'.",
+            search: "--",
+            skipCode: true,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+  t.is(
+    ...applyFixes(inputFile, markdownlint.sync(options), "options-tests.md"),
+    "Output doesn't match."
+  );
+});
+
+test("applyPatternFixWithoutReplace", (t) => {
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "m-dash",
+            message: "Don't use '--'.",
+            searchPattern: "/--/g",
+            skipCode: true,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+  t.is(
+    ...applyFixes(inputFile, markdownlint.sync(options), "options-tests.md"),
+    "Output doesn't match."
+  );
+});

--- a/tests/data/applyFixReplaceBackticks.md
+++ b/tests/data/applyFixReplaceBackticks.md
@@ -1,0 +1,10 @@
+# Header
+
+-- some text
+some -- text
+some text --
+inline code `let i = 2;` some code.
+
+````js
+// some code
+````

--- a/tests/data/applyFixReplaceBackticks.out.md
+++ b/tests/data/applyFixReplaceBackticks.out.md
@@ -1,0 +1,10 @@
+# Header
+
+-- some text
+some -- text
+some text --
+inline code `let i = 2;` some code.
+
+```js
+// some code
+```


### PR DESCRIPTION
The PR makes the configuration option '[replace](https://github.com/OnkarRuikar/markdownlint-rule-search-replace#using-markdownlintjson-config-file)' optional.
If `replace` is not provided for a search-replace rule, and `--fix` flag is used with markdownlint-cli, then it'll just report the issues 
 and files won't be modified for the rule.