### PR TITLE
Make it compatible with markdownlint v0.27.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,20 @@
+name: Check PR contents
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on:  ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Install Dependencies
+        run: npm install --no-package-lock
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "markdownlint-rule-helpers": "~0.18.0"
+        "markdownlint-rule-helpers": "~0.17.2"
       },
       "devDependencies": {
         "ava": "^5.0.1",
@@ -19,7 +19,7 @@
         "eslint-plugin-jsdoc": "^39.3.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-unicorn": "^45.0.0",
-        "markdownlint": "^0.27.0",
+        "markdownlint": "^0.26.2",
         "prettier": "^2.7.1"
       },
       "engines": {
@@ -2144,23 +2144,23 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.27.0.tgz",
-      "integrity": "sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.26.2.tgz",
+      "integrity": "sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==",
       "dev": true,
       "dependencies": {
         "markdown-it": "13.0.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=14"
       }
     },
     "node_modules/markdownlint-rule-helpers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.18.0.tgz",
-      "integrity": "sha512-UEdWfsoLr8ylXxfh4fzY5P6lExN+7Un7LbfqDXPlq5VLwwEDFdcZ7EMXoaEKNzncBKG/KWrt2sVt7KiCJgPyMQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz",
+      "integrity": "sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA==",
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=12"
       }
     },
     "node_modules/matcher": {
@@ -5165,18 +5165,18 @@
       }
     },
     "markdownlint": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.27.0.tgz",
-      "integrity": "sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.26.2.tgz",
+      "integrity": "sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==",
       "dev": true,
       "requires": {
         "markdown-it": "13.0.1"
       }
     },
     "markdownlint-rule-helpers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.18.0.tgz",
-      "integrity": "sha512-UEdWfsoLr8ylXxfh4fzY5P6lExN+7Un7LbfqDXPlq5VLwwEDFdcZ7EMXoaEKNzncBKG/KWrt2sVt7KiCJgPyMQ=="
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz",
+      "integrity": "sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA=="
     },
     "matcher": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "markdownlint-rule-helpers": "~0.18.0"
+    "markdownlint-rule-helpers": "~0.17.2"
   },
   "devDependencies": {
     "ava": "^5.0.1",
@@ -38,7 +38,7 @@
     "eslint-plugin-jsdoc": "^39.3.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^45.0.0",
-    "markdownlint": "^0.27.0",
+    "markdownlint": "^0.26.2",
     "prettier": "^2.7.1"
   }
 }

--- a/rule.js
+++ b/rule.js
@@ -47,7 +47,7 @@ const getLocation = (pos, lines) => {
  * @returns {number[][]} An array of tuple [lineNo, column, length].
  */
 const gatHtmlCommentRanges = (content, lines) => {
-  const regex = /<!--[.\n]*-->/gm;
+  const regex = /<!--[.\n\s]*-->/gm;
   const ranges = [];
   let match = null;
   while ((match = regex.exec(content)) !== null) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -11,7 +11,7 @@ function applyFixes(file, result, expected) {
   const fixes = result[file].filter((error) => error.fixInfo);
   result = helper.applyFixes(originalText, fixes);
   expected = fs.readFileSync(dataPath + expected, fsOptions);
-  return [result, expected];
+  return [expected, result];
 }
 
 module.exports.applyFixes = applyFixes;


### PR DESCRIPTION
Intermediate state before markdonwlint v0.27.0.

1. The v0.27.0 changed cleared HTML text from
`<!--..........-->`
to
`<!-- ... . .. -->`
The PR updates a regex to address this.

2. Making code compatible with markdownlint v0.26.2.

3. Adds PR check workflow

4. Small correction in testing framework.