### PR TITLE
Add search list to rules

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,12 +2,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '0 1 * * 6'
+    - cron: "0 1 * * 6"
 
 jobs:
   analyze:
@@ -21,20 +21,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on:  ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -18,3 +18,7 @@ jobs:
         run: npm install --no-package-lock
       - name: Run tests
         run: npm test
+      - name: Lint
+        run: npm run lint-check
+      - name: Pretty
+        run: npm run pretty-check

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example,
 
 Or specific cases like replace three backticks with one. [[ref](https://github.com/DavidAnson/markdownlint/issues/411)]
 
-Or ban certain words.
+Or ban certain words e.g. "wtf".
 
 In such scenarios the `markdownlint-rule-search-replace` rule can be used to flag or fix such occurrences.
 
@@ -66,11 +66,11 @@ Here,
 - `search-replace`: The rule configuration object.
 - `rules`: An array of search-replace definitions.
 - search-replace definition: defines search term/pattern and replacement.
-  - `name`: name of the definition
-  - `message`: corresponding message
-  - `search`: text to search
-  - `searchPattern`: regex pattern to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
-  - `replace`: Optional. The replacement string, e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
+  - `name`: name of the definition.
+  - `message`: corresponding message.
+  - `search`: text or array of texts to search
+  - `searchPattern`: regex pattern or array of patterns to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
+  - `replace`: Optional. The replacement string(s), e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
   - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped.
 
 Note, `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.
@@ -94,6 +94,27 @@ In patterns, to escape characters use `\\`. For example,
 ```
 
 This will replace line `...abcd...` with `-- abcd --`.
+
+A list of words and corresponding list of replacements can be provided in a single rule:
+
+```json
+{
+  "default": true,
+  "search-replace": {
+    "rules": [
+      {
+        "name": "bad-spellings",
+        "message": "Incorrect spelling",
+        "search": ["e-mail", "wtf", "web site"],
+        "replace": ["email", , "website"],
+        "skipCode": false
+      }
+    ]
+  }
+}
+```
+
+This is a good way to group related search replace terms in one rule. Make sure the replacements are at same indices as the corresponding search terms. In above example, the word "wtf" will get flagged but won't be auto fixed. Use empty replacement(`""`) if you wish to remove it.
 
 ### Disable rule options
 
@@ -164,6 +185,7 @@ markdownlint(options, function callback(err, result) {
   }
 });
 ```
+
 ## Projects using this custom rule
 
 - MDN Web Docs - [code](https://github.com/mdn/content/blob/main/.markdownlint-cli2.jsonc#L125)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownlint-rule-search-replace",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "markdownlint-rule-helpers": "~0.17.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",
@@ -20,6 +20,7 @@
   "private": false,
   "scripts": {
     "test": "ava tests/*-tests.js",
+    "lint-check": "eslint --max-warnings 0 .",
     "lint": "eslint --max-warnings 0 --fix .",
     "pretty-check": "prettier --check .",
     "pretty": "prettier --write ."

--- a/tests/applyFix-tests.js
+++ b/tests/applyFix-tests.js
@@ -15,7 +15,7 @@ test("applyFixDefault", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             search: "--",
             replace: "—",
           },
@@ -44,7 +44,7 @@ test("applyFixRegex", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             searchPattern: "/--/g",
             replace: "—",
           },
@@ -73,7 +73,7 @@ test("applyFixSkipCode", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             search: "--",
             replace: "—",
             skipCode: true,
@@ -104,7 +104,7 @@ test("applyFixReplaceBackticks", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             search: "````",
             replace: "```",
             skipCode: true,
@@ -134,7 +134,7 @@ test("applyFixWithoutReplace", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             search: "--",
             skipCode: true,
           },
@@ -159,7 +159,7 @@ test("applyPatternFixWithoutReplace", (t) => {
         rules: [
           {
             name: "m-dash",
-            message: "Don't use '--'.",
+            message: "Don't use '--'",
             searchPattern: "/--/g",
             skipCode: true,
           },
@@ -172,6 +172,70 @@ test("applyPatternFixWithoutReplace", (t) => {
   };
   t.is(
     ...applyFixes(inputFile, markdownlint.sync(options), "options-tests.md"),
+    "Output doesn't match."
+  );
+});
+
+test("applyFixOnSearchListDefault", (t) => {
+  const inputFile2 = "./tests/data/multivalue_search.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "bad-spellings",
+            message: "Incorrect spelling",
+            search: ["e-mail", "ohh no", "web site"],
+            // eslint-disable-next-line no-sparse-arrays
+            replace: ["email", , "website"],
+            skipCode: false,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile2],
+  };
+  t.is(
+    ...applyFixes(
+      inputFile2,
+      markdownlint.sync(options),
+      "applyMultivalueFixDefault.out.md"
+    ),
+    "Output doesn't match."
+  );
+});
+
+test("applyFixOnSearchListRegex", (t) => {
+  const inputFile2 = "./tests/data/multivalue_search.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "bad-spellings",
+            message: "Incorrect spelling",
+            searchPattern: ["/e-mail/g", "/ohh no/gi", "/web site/g"],
+            // eslint-disable-next-line no-sparse-arrays
+            replace: ["email", , "website"],
+            skipCode: false,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile2],
+  };
+  t.is(
+    ...applyFixes(
+      inputFile2,
+      markdownlint.sync(options),
+      "applyMultivalueFixDefault.out.md"
+    ),
     "Output doesn't match."
   );
 });

--- a/tests/data/applyMultivalueFixDefault.out.md
+++ b/tests/data/applyMultivalueFixDefault.out.md
@@ -1,0 +1,9 @@
+# Header
+
+Ohh no! Don't use old words like email, website etc.
+Use new spellings email, website instead.
+
+```js
+// email id
+// URL of a website to open.
+```

--- a/tests/data/multivalue_search.md
+++ b/tests/data/multivalue_search.md
@@ -1,0 +1,9 @@
+# Header
+
+Ohh no! Don't use old words like e-mail, web site etc.
+Use new spellings email, website instead.
+
+```js
+// e-mail id
+// URL of a web site to open.
+```

--- a/tests/options-tests.js
+++ b/tests/options-tests.js
@@ -90,3 +90,34 @@ test("checkPropertiesSkipCode", (t) => {
 ./tests/data/options-tests.md: 5: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 11 text:'--'"]`;
   t.is(result.toString(), expected, "Unexpected result.");
 });
+
+test("checkPropertiesSearchList", (t) => {
+  const inputFile2 = "./tests/data/multivalue_search.md";
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "bad-spellings",
+            message: "Incorrect spelling",
+            searchPattern: ["/e-mail/g", "/ohh no/gi", "/web site/g"],
+            // eslint-disable-next-line no-sparse-arrays
+            replace: ["email", , "website"],
+            skipCode: false,
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile2],
+  };
+  const result = markdownlint.sync(options);
+  const expected = `./tests/data/multivalue_search.md: 3: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 34 text:'e-mail'"]
+./tests/data/multivalue_search.md: 3: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 1 text:'Ohh no'"]
+./tests/data/multivalue_search.md: 3: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 42 text:'web site'"]
+./tests/data/multivalue_search.md: 7: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 4 text:'e-mail'"]
+./tests/data/multivalue_search.md: 8: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 13 text:'web site'"]`;
+  t.is(result.toString(), expected, "Unexpected result.");
+});


### PR DESCRIPTION
The PR adds a new feature.
A list of words and corresponding list of replacements can be provided in a single rule. This is a good way to group related search replace terms in one rule.
```json
{
  "default": true,
  "search-replace": {
    "rules": [
      {
        "name": "bad-spellings",
        "message": "Incorrect spelling",
        "search": ["e-mail", "wtf", "web site"],
        "replace": ["email", , "website"],
        "skipCode": false
      }
    ]
  }
}
```
Make sure the replacements are at same indices as the corresponding search terms. In above example, the word "wtf" will get flagged but won't be auto fixed. Use empty replacement(`""`) if you wish to remove it.

Similarly the option `searchPattern` can also be an array.