### PR TITLE
Publish upstream dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownlint-rule-search-replace",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "markdownlint-rule-helpers": "~0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",


### PR DESCRIPTION
Publishing the package with following dependency versions:
markdownlint-rule-helpers v0.18.0
markdownlint v0.27.0