### PR TITLE
Throw error when search option is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Here,
   - `replace`: Optional. The replacement string(s), e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
   - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped.
 
-Note, `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.
+Properties are case-sensitive and are in camel case.\
+**Note:** `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.
 
 In patterns, to escape characters use `\\`. For example,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdownlint-rule-search-replace",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "markdownlint-rule-helpers": "~0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",

--- a/rule.js
+++ b/rule.js
@@ -175,6 +175,10 @@ module.exports = {
     }
 
     for (const rule of rules) {
+      if (!rule.search && !rule.searchPattern) {
+        throw new Error("Provide either `search` or `searchPattern` option.");
+      }
+
       const regex = rule.search
         ? new RegExp(escapeForRegExp(rule.search), "g")
         : stringToRegex(rule.searchPattern);

--- a/tests/options-tests.js
+++ b/tests/options-tests.js
@@ -8,6 +8,44 @@ const searchReplace = require("../rule");
 
 const inputFile = "./tests/data/options-tests.md";
 
+test("checkMandatoryProerties", (t) => {
+  let options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [{}],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+
+  t.throws(() => markdownlint.sync(options), {
+    message: "Provide either `search` or `searchPattern` option.",
+  });
+
+  options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            searchpattern: "/abc/g",
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+
+  t.throws(() => markdownlint.sync(options), {
+    message: "Provide either `search` or `searchPattern` option.",
+  });
+});
+
 test("checkPropertiesDefault", (t) => {
   const options = {
     config: {


### PR DESCRIPTION
- Addresses https://github.com/OnkarRuikar/markdownlint-rule-search-replace/issues/56

When option `searchpattern` is used the code throws error:
> Cannot read properties of undefined (reading 'match')]

When `searchPattern` or `search` options are not provided the code needs to mention it.