### PR TITLE
Add option to *only* search in code blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For example,
         "message": "Do not use three dots '...' for ellipsis.",
         "search": "...",
         "replace": "…",
-        "skipCode": true
+        "searchScope": "text"
       },
       {
         "name": "curly-double-quotes",
@@ -71,8 +71,11 @@ Here,
   - `search`: text or array of texts to search
   - `searchPattern`: regex pattern or array of patterns to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
   - `replace`: Optional. The replacement string(s), e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
-  - `searchInCode` Optional. When set to `"skip"` all code(inline and block), which is inside backticks, will be skipped. When set to `"only"` only code will be searched. Default is `"all"` (both code and non-code is searched).
-  - `skipCode`: Optional. Equivalent to `"searchInCode": "skip"` when set to `true`.
+  - `searchScope` Optional. Scope to perform the search in.
+    - `all`: Default. Search in all Markdown content.
+    - `code`: Search only in code (block and inline). That is code inside code fences and inline backticks.
+    - `text`: Search only in markdown text, skip code.
+  - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped. _This property is deprecated use `searchScope` instead._
 
 Properties are case-sensitive and are in camel case.\
 **Note:** `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.
@@ -109,7 +112,7 @@ A list of words and corresponding list of replacements can be provided in a sing
         "message": "Incorrect spelling",
         "search": ["e-mail", "wtf", "web site"],
         "replace": ["email", null, "website"],
-        "skipCode": false
+        "searchScope": "all"
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Here,
   - `search`: text or array of texts to search
   - `searchPattern`: regex pattern or array of patterns to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
   - `replace`: Optional. The replacement string(s), e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
-  - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped.
+  - `searchInCode` Optional. When set to `"skip"` all code(inline and block), which is inside backticks, will be skipped. When set to `"only"` only code will be searched. Default is `"all"` (both code and non-code is searched).
+  - `skipCode`: Optional. Equivalent to `"searchInCode": "skip"` when set to `true`.
 
 Properties are case-sensitive and are in camel case.\
 **Note:** `search` and `searchPattern` are interchangeable. The property `search` is used if both are supplied.

--- a/rule.js
+++ b/rule.js
@@ -179,13 +179,17 @@ module.exports = {
         throw new Error("Provide either `search` or `searchPattern` option.");
       }
 
-      if (rule.searchInCode !== undefined) {
-        if (!["all", "only", "skip"].includes(rule.searchInCode)) {
-          throw new Error(`Invalid value \`${rule.searchInCode}\` provided for \`searchInCode\`, must be one of \`"all"\`, \`"only"\` or \`"skip"\`.`);
+      if (rule.searchScope !== undefined) {
+        if (rule.skipCode !== undefined) {
+          throw new Error(
+            "Both `searchScope` and `skipCode` specified, `skipCode` is deprecated, use `searchScope` instead."
+          );
         }
 
-        if (rule.skipCode && rule.searchInCode != "skip") {
-          throw new Error(`Option \`searchInCode\` = \`"${rule.searchInCode}"\` conflicts with \`skipCode\` = \`${rule.skipCode}\`.`)
+        if (!["all", "code", "text"].includes(rule.searchScope)) {
+          throw new Error(
+            `Invalid value \`${rule.searchScope}\` provided for \`searchScope\`, must be one of \`all\`, \`code\` or \`text\`.`
+          );
         }
       }
 
@@ -195,12 +199,8 @@ module.exports = {
       let result = null;
       while ((result = regex.exec(content)) !== null) {
         if (isCode(result.index, codeRanges, params.lines)) {
-          if (rule.skipCode || rule.searchInCode == "skip")
-            continue;
-        } else {
-          if (rule.searchInCode == "only")
-            continue;
-        }
+          if (rule.skipCode || rule.searchScope === "text") continue;
+        } else if (rule.searchScope === "code") continue;
 
         if (isHTMLComment(result.index, htmlCommentRanges, params.lines)) {
           continue;

--- a/tests/options-tests.js
+++ b/tests/options-tests.js
@@ -103,43 +103,6 @@ test("checkPropertiesRegex", (t) => {
 });
 
 test("checkPropertiesSkipCode", (t) => {
-  let options = {
-    config: {
-      default: true,
-      "search-replace": {
-        rules: [
-          {
-            name: "m-dash",
-            message: "Don't use '--'.",
-            search: "--",
-            replace: "—",
-          },
-        ],
-      },
-    },
-    customRules: [searchReplace],
-    resultVersion: 3,
-    files: [inputFile],
-  };
-
-  // Check skip via searchInCode: "only"
-  options.config["search-replace"].rules[0].searchInCode = "skip";
-  const check = (options) => {
-    const result = markdownlint.sync(options);
-    const expected = `./tests/data/options-tests.md: 3: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 1 text:'--'"]
-./tests/data/options-tests.md: 4: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 6 text:'--'"]
-./tests/data/options-tests.md: 5: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 11 text:'--'"]`;
-    t.is(result.toString(), expected, "Unexpected result.");
-  };
-  check(options);
-
-  // Check skip via skipCode: true
-  delete options.config["search-replace"].rules[0].searchInCode;
-  options.config["search-replace"].rules[0].skipCode = true;
-  check(options);
-});
-
-test("checkPropertiesSearchInCodeOnly", (t) => {
   const options = {
     config: {
       default: true,
@@ -150,7 +113,44 @@ test("checkPropertiesSearchInCodeOnly", (t) => {
             message: "Don't use '--'.",
             search: "--",
             replace: "—",
-            searchInCode: "only",
+          },
+        ],
+      },
+    },
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+
+  // Check skip via searchScope: "text"
+  options.config["search-replace"].rules[0].searchScope = "text";
+  const check = (opts) => {
+    const result = markdownlint.sync(opts);
+    const expected = `./tests/data/options-tests.md: 3: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 1 text:'--'"]
+./tests/data/options-tests.md: 4: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 6 text:'--'"]
+./tests/data/options-tests.md: 5: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 11 text:'--'"]`;
+    t.is(result.toString(), expected, "Unexpected result.");
+  };
+  check(options);
+
+  // Check skip via skipCode: true
+  delete options.config["search-replace"].rules[0].searchScope;
+  options.config["search-replace"].rules[0].skipCode = true;
+  check(options);
+});
+
+test("checkPropertiesSearchScopeCode", (t) => {
+  const options = {
+    config: {
+      default: true,
+      "search-replace": {
+        rules: [
+          {
+            name: "m-dash",
+            message: "Don't use '--'.",
+            search: "--",
+            replace: "—",
+            searchScope: "code",
           },
         ],
       },
@@ -161,41 +161,44 @@ test("checkPropertiesSearchInCodeOnly", (t) => {
   };
   const result = markdownlint.sync(options);
   const expected = `./tests/data/options-tests.md: 6: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 18 text:'--'"]
-./tests/data/options-tests.md: 9: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 15 text:'--'"]`
+./tests/data/options-tests.md: 9: search-replace Custom rule [m-dash: Don't use '--'.] [Context: "column: 15 text:'--'"]`;
   t.is(result.toString(), expected, "Unexpected result.");
 });
 
-test("checkPropertiesSearchInCodeConflict", (t) => {
-  ["all", "only"].forEach(setting => {
-    const options = {
-      config: {
-        default: true,
-        "search-replace": {
-          rules: [
-            {
-              name: "m-dash",
-              message: "Don't use '--'.",
-              search: "--",
-              replace: "—",
-              skipCode: true,
-              searchInCode: setting
-            },
-          ],
+test("checkPropertiesSearchScopeWarning", (t) => {
+  for (const searchScopeValue of ["all", "code", "text"]) {
+    for (const skipCodeValue of [true, false]) {
+      const options = {
+        config: {
+          default: true,
+          "search-replace": {
+            rules: [
+              {
+                name: "m-dash",
+                message: "Don't use '--'.",
+                search: "--",
+                replace: "—",
+                skipCode: skipCodeValue,
+                searchScope: searchScopeValue,
+              },
+            ],
+          },
         },
-      },
-      customRules: [searchReplace],
-      resultVersion: 3,
-      files: [inputFile],
-    };
+        customRules: [searchReplace],
+        resultVersion: 3,
+        files: [inputFile],
+      };
 
-    t.throws(() => markdownlint.sync(options), {
-      message: `Option \`searchInCode\` = \`"${setting}"\` conflicts with \`skipCode\` = \`true\`.`,
-    });
-  });
+      t.throws(() => markdownlint.sync(options), {
+        message:
+          "Both `searchScope` and `skipCode` specified, `skipCode` is deprecated, use `searchScope` instead.",
+      });
+    }
+  }
 });
 
-test("checkPropertiesSearchInCodeInvalid", (t) => {
-  ["", false, "yes", { "asd": true }].forEach(setting => {
+test("checkPropertiesSearchScopeInvalid", (t) => {
+  for (const setting of ["", false, "yes", { asd: true }]) {
     const options = {
       config: {
         default: true,
@@ -206,7 +209,7 @@ test("checkPropertiesSearchInCodeInvalid", (t) => {
               message: "Don't use '--'.",
               search: "--",
               replace: "—",
-              searchInCode: setting
+              searchScope: setting,
             },
           ],
         },
@@ -217,9 +220,9 @@ test("checkPropertiesSearchInCodeInvalid", (t) => {
     };
 
     t.throws(() => markdownlint.sync(options), {
-      message: `Invalid value \`${setting}\` provided for \`searchInCode\`, must be one of \`"all"\`, \`"only"\` or \`"skip"\`.`,
+      message: `Invalid value \`${setting}\` provided for \`searchScope\`, must be one of \`all\`, \`code\` or \`text\`.`,
     });
-  });
+  }
 });
 
 test("checkPropertiesSearchList", (t) => {


### PR DESCRIPTION
Extend the `skipCode` with a new setting `searchInCode` that allows for all possibilities of searching in code for rules
- `searchInCode: "all"` is the default behavior where nothing is skipped
- `searchInCode: "skip"` is equivalent to `skipCode: true` where code is skipped.
- `searchInCode: "only"` skips everything, but code.

My use-case is banning em-dashes(`–`) only in code blocks, where probably a dash(`-`) was meant instead.
I.e.
```json
{
  "search-replace": {
    "rules": [
      {
        "name": "Misspelled hyphen",
        "message": "Suspicious long dash in code, did you mean to use hyphen(-)?",
        "searchPattern": "—|–",
        "replace": "-",
        "searchInCode":"only"
      }
    ]
  }
}
```