### PR TITLE
Treat null the same as undefined in replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A list of words and corresponding list of replacements can be provided in a sing
         "name": "bad-spellings",
         "message": "Incorrect spelling",
         "search": ["e-mail", "wtf", "web site"],
-        "replace": ["email", , "website"],
+        "replace": ["email", null, "website"],
         "skipCode": false
       }
     ]

--- a/rule.js
+++ b/rule.js
@@ -210,7 +210,7 @@ module.exports = {
           }
         } else {
           let replacement = null;
-          if (rule.replace !== undefined) {
+          if (rule.replace !== undefined && rule.replace !== null) {
             replacement = rule.search
               ? rule.replace
               : match.replace(new RegExp(regex), rule.replace);

--- a/tests/applyFix-tests.js
+++ b/tests/applyFix-tests.js
@@ -210,7 +210,7 @@ test("applyFixOnSearchListDefault", (t) => {
 
 test("applyFixOnSearchListRegex", (t) => {
   const inputFile2 = "./tests/data/multivalue_search.md";
-  [undefined, null].forEach(no_replacement => {
+  for (const noReplacement of [undefined, null]) {
     const options = {
       config: {
         default: true,
@@ -220,7 +220,7 @@ test("applyFixOnSearchListRegex", (t) => {
               name: "bad-spellings",
               message: "Incorrect spelling",
               searchPattern: ["/e-mail/g", "/ohh no/gi", "/web site/g"],
-              replace: ["email", no_replacement, "website"],
+              replace: ["email", noReplacement, "website"],
               skipCode: false,
             },
           ],
@@ -238,5 +238,5 @@ test("applyFixOnSearchListRegex", (t) => {
       ),
       "Output doesn't match."
     );
-  });
+  }
 });

--- a/tests/applyFix-tests.js
+++ b/tests/applyFix-tests.js
@@ -210,32 +210,33 @@ test("applyFixOnSearchListDefault", (t) => {
 
 test("applyFixOnSearchListRegex", (t) => {
   const inputFile2 = "./tests/data/multivalue_search.md";
-  const options = {
-    config: {
-      default: true,
-      "search-replace": {
-        rules: [
-          {
-            name: "bad-spellings",
-            message: "Incorrect spelling",
-            searchPattern: ["/e-mail/g", "/ohh no/gi", "/web site/g"],
-            // eslint-disable-next-line no-sparse-arrays
-            replace: ["email", , "website"],
-            skipCode: false,
-          },
-        ],
+  [undefined, null].forEach(no_replacement => {
+    const options = {
+      config: {
+        default: true,
+        "search-replace": {
+          rules: [
+            {
+              name: "bad-spellings",
+              message: "Incorrect spelling",
+              searchPattern: ["/e-mail/g", "/ohh no/gi", "/web site/g"],
+              replace: ["email", no_replacement, "website"],
+              skipCode: false,
+            },
+          ],
+        },
       },
-    },
-    customRules: [searchReplace],
-    resultVersion: 3,
-    files: [inputFile2],
-  };
-  t.is(
-    ...applyFixes(
-      inputFile2,
-      markdownlint.sync(options),
-      "applyMultivalueFixDefault.out.md"
-    ),
-    "Output doesn't match."
-  );
+      customRules: [searchReplace],
+      resultVersion: 3,
+      files: [inputFile2],
+    };
+    t.is(
+      ...applyFixes(
+        inputFile2,
+        markdownlint.sync(options),
+        "applyMultivalueFixDefault.out.md"
+      ),
+      "Output doesn't match."
+    );
+  });
 });


### PR DESCRIPTION
That is don't provide a replacement, just mark the occurrence of the word as the error.
JSON and YAML don't have `undefined`, to specify no replacement in multi-word rules in config files `null` can now be used. Previously setting `replace` to `null` would replace the result with `"null"`.

Fixes: #103 