### PR TITLE
feat(rule): custom information URL for each sub-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For example,
       {
         "name": "ellipsis",
         "message": "Do not use three dots '...' for ellipsis.",
+        "information": "https://example.com/rules/ellipsis",
         "search": "...",
         "replace": "…",
         "searchScope": "text"
@@ -66,15 +67,16 @@ Here,
 - `search-replace`: The rule configuration object.
 - `rules`: An array of search-replace definitions.
 - search-replace definition: defines search term/pattern and replacement.
-  - `name`: name of the definition.
-  - `message`: corresponding message.
-  - `search`: text or array of texts to search
-  - `searchPattern`: regex pattern or array of patterns to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
+  - `name`: Name of the definition.
+  - `message`: Corresponding message.
+  - `information`: Optional. An absolute URL of a link to more information about the sub-rule.
+  - `search`: Text or array of texts to search.
+  - `searchPattern`: Regex pattern or array of patterns to search. Include flags as well, as if you are defining a regex literal in JavaScript, e.g. `/http/g`.
   - `replace`: Optional. The replacement string(s), e.g. `https`. Regex properties like `$1` can be used if `searchPattern` is being used.
   - `searchScope` Optional. Scope to perform the search in.
     - `all`: Default. Search in all Markdown content.
     - `code`: Search only in code (block and inline). That is code inside code fences and inline backticks.
-    - `text`: Search only in markdown text, skip code.
+    - `text`: Search only in Markdown text, skip code.
   - `skipCode`: Optional. All code(inline and block), which is inside backticks, will be skipped. _This property is deprecated use `searchScope` instead._
 
 Properties are case-sensitive and are in camel case.\

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rule-search-replace",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A custom markdownlint rule for search and replaces",
   "main": "rule.js",
   "author": "Onkar Ruikar",

--- a/tests/options-tests.js
+++ b/tests/options-tests.js
@@ -6,6 +6,7 @@ const test = require("ava").default;
 const markdownlint = require("markdownlint");
 const searchReplace = require("../rule");
 const check = require("./utils").check;
+const checkRuleInformation = require("./utils").checkRuleInformation;
 
 const inputFile = "./tests/data/options-tests.md";
 
@@ -250,4 +251,38 @@ test("checkPropertiesSearchList", (t) => {
 ./tests/data/multivalue_search.md: 8: search-replace Custom rule [bad-spellings: Incorrect spelling] [Context: "column: 13 text:'web site'"]`;
 
   check(t, options, expected);
+});
+
+test("checkPropertyInformation", (t) => {
+  const options = {
+    config: JSON.parse(`{
+      "default": true,
+      "search-replace": {
+        "rules": [
+          {
+            "name": "m-dash",
+            "message": "Don't use '--'.",
+            "information": "https://example.com/rules/ellipsis",
+            "searchPattern": "/--/g",
+            "replace": "—"
+          }
+        ]
+      }
+    }`),
+    customRules: [searchReplace],
+    resultVersion: 3,
+    files: [inputFile],
+  };
+
+  checkRuleInformation(t, options);
+
+  // check bad URL
+  options.config["search-replace"].rules[0].information = "bad-url";
+  t.throws(() => markdownlint.sync(options), {
+    message: "Provide valid 'information' URL: bad-url",
+  });
+
+  // check default
+  delete options.config["search-replace"].rules[0].information;
+  checkRuleInformation(t, options);
 });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -6,6 +6,8 @@ const markdownlint = require("markdownlint");
 
 const fsOptions = { encoding: "utf8" };
 const dataPath = "./tests/data/";
+const INFO_URL =
+  "https://github.com/OnkarRuikar/markdownlint-rule-search-replace";
 
 function check(executionContext, options, expected) {
   const result = markdownlint.sync(options);
@@ -27,5 +29,29 @@ function checkFix(executionContext, options, inputFile, outputFile) {
   );
 }
 
+function checkRuleInformation(executionContext, options) {
+  const ruleInfoMap = new Map();
+  for (const rule of options.config["search-replace"].rules) {
+    if (rule.information === undefined) {
+      ruleInfoMap.set(`${rule.name}: ${rule.message}`, INFO_URL);
+    } else {
+      ruleInfoMap.set(`${rule.name}: ${rule.message}`, rule.information);
+    }
+  }
+
+  const results = markdownlint.sync(options);
+  for (const file of Object.keys(results)) {
+    const fileErrors = results[file];
+    for (const error of fileErrors) {
+      executionContext.is(
+        error.ruleInformation,
+        ruleInfoMap.get(error.errorDetail),
+        `Information URL doesn't match for rule: ${error.errorDetail}`,
+      );
+    }
+  }
+}
+
 module.exports.check = check;
 module.exports.checkFix = checkFix;
+module.exports.checkRuleInformation = checkRuleInformation;


### PR DESCRIPTION
- fixes https://github.com/OnkarRuikar/markdownlint-rule-search-replace/issues/108

The PR adds ability to provide a separate information URLs for each sub-rule:
```json
{
  "default": true,
   "search-replace": {
    "rules": [
      {
        "name": "ellipsis",
        "message": "Do not use three dots '...' for ellipsis.",
        "search": "...",
        "information": "https://example.com/rules/ellipsis"
      },
      {
        "name": "curly-double-quotes",
        "message": "Do not use curly double quotes.",
        "searchPattern": "/“|”/g"
      }
    ]
  }
}
```
In above example, sub-rule `ellipsis` will show `https ://example.com/rules/ellipsis` as information URL in error messages related to it. And sub-rule `curly-double-quotes` will show the default `https ://github.com/OnkarRuikar/markdownlint-rule-search-replace` information URLs in error message related to it.

The information URL has to be an absolute URL which could be parsed by JavaScript [`new URL(string)` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).